### PR TITLE
docs: GitHub Flow開発フローの文書化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,50 @@ Chrome拡張機能のため、通常のWebサーバーでは動作しません�
 3. 「パッケージ化されていない拡張機能を読み込む」でプロジェクトルートを選択
 4. LINE Developersサイトで動作確認
 
+## 開発フロー（GitHub Flow）
+
+このプロジェクトはGitHub Flowを採用しています。**mainブランチに直接pushすることは禁止**されています。
+
+### 開発手順
+
+1. **フィーチャーブランチの作成**
+   ```bash
+   git checkout -b feature/description-of-change
+   ```
+   - ブランチ名は `feature/`, `fix/`, `docs/` などのプレフィックスを推奨
+
+2. **変更の実装**
+   - 必要なコード変更を実装
+
+3. **品質チェック（必須）**
+   ```bash
+   npm run check     # リント・フォーマット
+   npm test          # ユニットテスト
+   npm run build     # ビルド確認
+   ```
+   - **すべてのチェックが通ることを必ず確認**
+
+4. **変更のコミット・プッシュ**
+   ```bash
+   git add .
+   git commit -m "適切なコミットメッセージ"
+   git push origin feature/description-of-change
+   ```
+
+5. **プルリクエストの作成（ghコマンド使用）**
+   ```bash
+   gh pr create --title "プルリクエストのタイトル" --body "変更内容の説明"
+   ```
+
+6. **レビュー・マージ**
+   - レビュアー（kaz9120）がレビューを実施
+   - 承認後、mainブランチにマージ
+
+### 注意事項
+- mainブランチへの直接pushは技術的に防止されています
+- プルリクエスト作成には必ずghコマンドを使用してください
+- 品質チェックが通らない場合は修正してから再度プッシュしてください
+
 ## プロジェクト概要
 
 LINE Developersのドキュメントページ用Chrome拡張機能。

--- a/README.md
+++ b/README.md
@@ -19,6 +19,38 @@ LINE DevelopersのドキュメントページからMarkdownをコピーできる
 
 ## 開発
 
+### 開発フロー
+
+このプロジェクトはGitHub Flowを採用しています：
+
+1. **フィーチャーブランチの作成**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **変更の実装**
+   - コードの修正・追加を行う
+
+3. **品質チェック**
+   ```bash
+   npm run check  # リント・フォーマット
+   npm test       # テスト実行
+   npm run build  # ビルド確認
+   ```
+
+4. **変更をプッシュ**
+   ```bash
+   git add .
+   git commit -m "your commit message"
+   git push origin feature/your-feature-name
+   ```
+
+5. **プルリクエストの作成**
+   - GitHub WebUIからプルリクエストを作成
+   - レビュー完了後、mainブランチにマージ
+
+**注意**: mainブランチに直接pushすることはできません。
+
 ### 必要な環境
 
 - Node.js 18+

--- a/src/strategies/document-strategy.ts
+++ b/src/strategies/document-strategy.ts
@@ -1,6 +1,6 @@
-import { BasePageStrategy } from "../page-strategies";
 import { SELECTORS } from "../constants";
 import { removeElements } from "../dom-utils";
+import { BasePageStrategy } from "../page-strategies";
 
 export class DocumentPageStrategy extends BasePageStrategy {
   readonly name = "document";

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,6 +1,6 @@
+import type { PageStrategy } from "../page-strategies";
 import { DocumentPageStrategy } from "./document-strategy";
 import { NewsPageStrategy } from "./news-strategy";
-import type { PageStrategy } from "../page-strategies";
 
 export const PAGE_STRATEGIES: ReadonlyArray<PageStrategy> = [
   new NewsPageStrategy(),

--- a/src/strategies/news-strategy.ts
+++ b/src/strategies/news-strategy.ts
@@ -1,7 +1,7 @@
 import type TurndownService from "turndown";
-import { BasePageStrategy } from "../page-strategies";
 import { NEWS_SELECTORS, SELECTORS } from "../constants";
 import { removeElements } from "../dom-utils";
+import { BasePageStrategy } from "../page-strategies";
 
 export class NewsPageStrategy extends BasePageStrategy {
   readonly name = "news";


### PR DESCRIPTION
## Summary
- README.mdに人間開発者向けのGitHub Flow開発手順を追加
- CLAUDE.mdにClaude Code向けの詳細な開発フロー手順を追加
- mainブランチへの直接push禁止を明記

## 変更内容
### README.md
- 「開発フロー」セクションを新規追加
- フィーチャーブランチ作成からPR作成までの手順を記載
- GitHub WebUIでのPR作成を案内

### CLAUDE.md
- 「開発フロー（GitHub Flow）」セクションを新規追加
- Claude Code向けにghコマンドによるPR作成手順を明記
- 品質チェック（lint/test/build）の必須化を強調

## Test plan
- [x] リント・フォーマットチェック（npm run check）
- [x] ユニットテスト実行（npm test）
- [x] ビルド確認（npm run build）

🤖 Generated with [Claude Code](https://claude.ai/code)