### PR TITLE
Add: 用語集ページの表形式変換機能

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,14 @@ export const NEWS_SELECTORS = {
   HR_SEPARATOR: "hr", // 区切り線
 } as const;
 
+export const GLOSSARY_SELECTORS = {
+  GLOSSARY_PAGE: ".glossary-page",
+  GLOSSARY_SECTION: ".glossary-section",
+  GLOSSARY_SECTION_HEADER: ".glossary-section-header",
+  GLOSSARY_ENTRY: ".glossary-entry",
+  SIDE_COLUMN: ".side-column", // 索引部分（除外対象）
+} as const;
+
 export const CSS_CLASSES = {
   CONTAINER: "markdown-copy-container",
   BUTTON: "copy-markdown-button",

--- a/src/strategies/document-strategy.ts
+++ b/src/strategies/document-strategy.ts
@@ -4,7 +4,7 @@ import { BasePageStrategy } from "../page-strategies";
 
 export class DocumentPageStrategy extends BasePageStrategy {
   readonly name = "document";
-  readonly urlPattern = /\/(docs|reference|faq|glossary|ja\/docs)\//;
+  readonly urlPattern = /\/(docs|reference|faq|ja\/docs)\//;
 
   readonly selectors = {
     title: SELECTORS.PAGE_TITLE,

--- a/src/strategies/glossary-strategy.ts
+++ b/src/strategies/glossary-strategy.ts
@@ -1,0 +1,95 @@
+import type TurndownService from "turndown";
+import { GLOSSARY_SELECTORS, SELECTORS } from "../constants";
+import { removeElements } from "../dom-utils";
+import { BasePageStrategy } from "../page-strategies";
+
+export class GlossaryPageStrategy extends BasePageStrategy {
+  readonly name = "glossary";
+  readonly urlPattern = /\/glossary\//;
+
+  readonly selectors = {
+    title: ".main-column h1", // 用語集ページのタイトルは h1 要素
+    content: SELECTORS.CONTENT_DEFAULT,
+    excludeElements: [
+      SELECTORS.HEADER_ANCHOR,
+      SELECTORS.COPY_BUTTON,
+      GLOSSARY_SELECTORS.SIDE_COLUMN,
+    ],
+  };
+
+  addCustomRules(turndownService: TurndownService): void {
+    // 用語集ページ全体を表形式に変換
+    turndownService.addRule("glossaryPage", {
+      filter: (node: HTMLElement) => {
+        return node.classList?.contains("glossary-page");
+      },
+      replacement: (_content: string, node: Node) => {
+        const element = node as Element;
+        return this.convertGlossaryToTable(element);
+      },
+    });
+  }
+
+  preprocessContent(contentElement: HTMLElement): void {
+    // 共通要素の削除
+    this.selectors.excludeElements?.forEach((selector) => {
+      removeElements(contentElement, selector);
+    });
+
+    // タイトル要素を取得してcontentElementの先頭に追加
+    const titleElement = this.getTitleElement();
+    if (titleElement) {
+      const titleClone = titleElement.cloneNode(true) as HTMLElement;
+      contentElement.insertBefore(titleClone, contentElement.firstChild);
+    }
+  }
+
+  private convertGlossaryToTable(glossaryElement: Element): string {
+    const sections = glossaryElement.querySelectorAll(
+      GLOSSARY_SELECTORS.GLOSSARY_SECTION,
+    );
+
+    if (sections.length === 0) {
+      return "";
+    }
+
+    // テーブルヘッダー
+    let table = "| 用語 | 説明 |\n";
+    table += "|------|------|\n";
+
+    // 各セクションを処理
+    sections.forEach((section) => {
+      const entries = section.querySelectorAll(
+        GLOSSARY_SELECTORS.GLOSSARY_ENTRY,
+      );
+
+      entries.forEach((entry) => {
+        const termElement = entry.querySelector("h3");
+        const descriptionElement = entry.querySelector("p");
+
+        if (termElement && descriptionElement) {
+          const term = this.cleanTermText(termElement.textContent || "");
+          const description = this.cleanDescriptionText(descriptionElement);
+
+          table += `| ${term} | ${description} |\n`;
+        }
+      });
+    });
+
+    return table + "\n";
+  }
+
+  private cleanTermText(text: string): string {
+    // "#" を削除し、余分な空白を削除
+    return text.replace(/^#\s*/, "").trim();
+  }
+
+  private cleanDescriptionText(element: Element): string {
+    // リンクのテキストのみ取得し、改行やマークダウン記号をエスケープ
+    let text = element.textContent || "";
+    text = text.replace(/\n/g, " "); // 改行を空白に置き換え
+    text = text.replace(/\s+/g, " "); // 連続する空白を単一の空白に
+    text = text.replace(/\|/g, "\\|"); // パイプ文字をエスケープ
+    return text.trim();
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,15 +1,17 @@
 import type { PageStrategy } from "../page-strategies";
 import { DocumentPageStrategy } from "./document-strategy";
+import { GlossaryPageStrategy } from "./glossary-strategy";
 import { NewsPageStrategy } from "./news-strategy";
 
 export const PAGE_STRATEGIES: ReadonlyArray<PageStrategy> = [
+  new GlossaryPageStrategy(), // 優先度高（特定のページ）
   new NewsPageStrategy(),
-  new DocumentPageStrategy(),
+  new DocumentPageStrategy(), // 優先度低（汎用）
 ] as const;
 
 export function detectCurrentPageStrategy(): PageStrategy | null {
   return PAGE_STRATEGIES.find((strategy) => strategy.detectPage()) || null;
 }
 
-export { DocumentPageStrategy, NewsPageStrategy };
+export { DocumentPageStrategy, GlossaryPageStrategy, NewsPageStrategy };
 export type { PageStrategy } from "../page-strategies";

--- a/src/style.css
+++ b/src/style.css
@@ -6,6 +6,11 @@
   border-bottom: 1px solid #e1e4e8;
 }
 
+/* 用語集ページ専用のスタイル */
+.glossary-page .markdown-copy-container {
+  margin-bottom: 32px;
+}
+
 /* ボタンのスタイル（Stripeライク） */
 .copy-markdown-button {
   background: transparent;


### PR DESCRIPTION
## Summary
LINE Developers用語集ページ（`/ja/glossary/`）を表形式に変換する新機能を実装

### 実装内容
- **GlossaryPageStrategy**: 用語集ページ専用のStrategyクラスを追加
- **表形式変換**: HTML構造から2列テーブル（用語 | 説明）に変換
- **タイトル追加**: Markdown出力にページタイトルを含める
- **スタイル調整**: 用語集ページ専用のボタン位置調整

### 変更ファイル
- `src/constants.ts` - 用語集ページ用セレクタを追加
- `src/strategies/glossary-strategy.ts` - 新規Strategy実装
- `src/strategies/index.ts` - Strategyを登録
- `src/strategies/document-strategy.ts` - URLパターンから用語集を除外
- `src/style.css` - 用語集ページ専用スタイル追加

### 出力例
```markdown
# LINEプラットフォーム用語集

| 用語 | 説明 |
|------|------|
| E.164 | E.164は、国際的に一意な電話番号の形式についての勧告です... |
| IDトークン | アプリに権限を付与したユーザーの情報を含むJSONウェブトークン... |
```

## Test plan
- [x] Chrome拡張機能として正常に動作
- [x] 用語集ページでボタンが表示される
- [x] 表形式のMarkdownが正しくコピーされる
- [x] 既存テストがすべて通過
- [x] ビルドが正常に完了

🤖 Generated with [Claude Code](https://claude.ai/code)